### PR TITLE
Made 2 quick changes.

### DIFF
--- a/config/smarty.php
+++ b/config/smarty.php
@@ -1,13 +1,16 @@
 <?php if (!defined('BASEPATH')) exit('No direct script access allowed');
 
 // Your views directory with a trailing slash
-$config['template_directory'] = APPPATH."views/";
+$config['template_directory']   = APPPATH."views/";
 
 // Where templates are compiled
-$config['compile_directory']  = BASEPATH."cache/smarty/compiled";
+$config['compile_directory']    = BASEPATH."cache/smarty/compiled";
 
 // Where templates are cached
-$config['cache_directory']    = APPPATH."cache/smarty/cached";
+$config['cache_directory']      = APPPATH."cache/smarty/cached";
 
 // Where Smarty configs are located
-$config['config_directory']   = APPPATH."third_party/Smarty/configs";
+$config['config_directory']     = APPPATH."third_party/Smarty/configs";
+
+// Default extension of templates if one isn't supplied
+$config['template_ext']         = 'php';

--- a/libraries/MY_Parser.php
+++ b/libraries/MY_Parser.php
@@ -33,26 +33,33 @@ class MY_Parser extends CI_Parser {
     * @param array $data
     * @param mixed $return
     */
-    public function parse($template, $data = '', $return = false, $use_theme = false)
+    public function parse($template, $data = '', $return = FALSE, $use_theme = FALSE)
     {
+        // Make sure we have a template, yo.
         if ($template == '')
         {
             return FALSE;
         }
         
-        if ($use_theme !== false)
+        // If we want to get a certain template from another location
+        if ($use_theme != FALSE)
         {
             $this->load->library('template');
             $template = "file:/".$this->template->get_theme_path().$template."";
         }
         
+        // If no file extension dot has been found default to .php for view extensions
         if ( !stripos($template, '.') ) 
         {
-            $template = $template.".tpl";
+            $template = $template.".".$this->smarty->template_ext;
         }
         
-        $data = array_merge($data, $this->load->_ci_cached_vars);
-        
+        // Merge in any cached variables with our supplied variables
+        if (is_array($data))
+        {
+            $data = array_merge($data, $this->load->_ci_cached_vars);
+        }
+        // If we have variables to assign, lets assign them
         if ($data)
         {
             foreach ($data as $key => $val)
@@ -61,17 +68,20 @@ class MY_Parser extends CI_Parser {
             }
         }
         
+        // Get our template data as a string
         $template_string = $this->smarty->fetch($template);
         
+        // If we're returning the templates contents, we're displaying the template
         if ($return == FALSE)
         {
             $this->output->append_output($template_string);
         }
         
+        // We're returning the contents, fo'' shizzle
         return $template_string;
     }
     
-    public function parse_string($template, $data = '', $return = false, $use_theme = FALSE)
+    public function parse_string($template, $data = '', $return = FALSE, $use_theme = FALSE)
     {
         return $this->parse($template, $data, $return, $use_theme);
     }

--- a/libraries/Smarty.php
+++ b/libraries/Smarty.php
@@ -20,6 +20,7 @@ class CI_Smarty extends Smarty {
         $this->compile_dir       = $this->CI->config->item('compile_directory');
         $this->cache_dir         = $this->CI->config->item('cache_directory');
         $this->config_dir        = $this->CI->config->item('config_directory');
+        $this->template_ext      = $this->CI->config->item('template_ext');
         $this->exception_handler = null;
 
         // Add all helpers to plugins_dir


### PR DESCRIPTION
I removed the hardcoded default of "tpl" as the template extension in My_Parser and replaced it with a config variable set in the smarty config file. Instead of re-loading the smarty config in the parser to get at the variable, I just added a variable in the smarty class and called that variable in the parser.

I also added that $data line wrapped in an "is_array" check.
