### PR TITLE
Exposed configuration option for error reporting level to use while processing templates

### DIFF
--- a/config/smarty.php
+++ b/config/smarty.php
@@ -24,3 +24,6 @@ $config['config_directory']     = APPPATH."third_party/Smarty/configs";
 
 // Default extension of templates if one isn't supplied
 $config['template_ext']         = 'php';
+
+// Error reporting level to use while processing templates
+$config['template_error_reporting'] = E_ALL & ~E_NOTICE;

--- a/libraries/MY_Parser.php
+++ b/libraries/MY_Parser.php
@@ -57,9 +57,6 @@ class MY_Parser extends CI_Parser {
             }
         }
         
-        // Set error reporting level
-        $this->CI->smarty->error_reporting = error_reporting();
-        
         // Get our template data as a string
         $template_string = $this->CI->smarty->fetch($template);
         

--- a/libraries/Smarty.php
+++ b/libraries/Smarty.php
@@ -28,6 +28,7 @@ class CI_Smarty extends Smarty {
         $this->cache_dir         = config_item('cache_directory');
         $this->config_dir        = config_item('config_directory');
         $this->template_ext      = config_item('template_ext');
+        $this->error_reporting   = config_item('template_error_reporting');
         $this->exception_handler = null;
 
         // Add all helpers to plugins_dir


### PR DESCRIPTION
I find it very useful to have a separate error level while Smarty is doing its thing, my development environment uses `E_ALL` which is very noisy as Smarty generates lots of notices. This patch allows you to set a separate error level while Smarty is processing (note that nothing has been changed within Smarty, it supports this out of the box) which reduces the noise.

A couple of notes:
1. The configuration option isn't very well named, locally I just call it 'error_level' but that seems likely to cause conflict (unless the way the library loads the configuration file is changed to isolate it from the rest of the configuration, I can roll a patch for this if you want).
2. I set the default to `E_ALL & ~E_NOTICE`, which is what I use... not sure if this is the best default for everyone, though. Maybe `error_level() & ~E_NOTICE`?
